### PR TITLE
Add Ctrl-M hotkey for mathquill textarea

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -369,6 +369,14 @@ var MathBlock = P(MathElement, function(_, super_) {
       ctrlr.escapeDir(key === 'Shift-Spacebar' ? L : R, key, e);
       return;
     }
+
+    if ( key === "Ctrl-M") {
+      if (!ctrlr.cursor[R])
+        ctrlr.cursor.insRightOf(this.parent);
+      else if (!ctrlr.cursor[L])
+        ctrlr.cursor.insLeftOf(this.parent);
+    }
+
     return super_.keystroke.apply(this, arguments);
   };
 

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -341,7 +341,7 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
     };
   };
   _.latex = function() {
-    return '$' + this.ends[L].latex() + '$';
+    return "\\mqmm " + this.ends[L].latex() + "\\endmqmm";
   };
 });
 
@@ -358,15 +358,10 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
   };
   _.write = function(cursor, ch) {
     cursor.show().deleteSelection();
-    //if (ch === '$') {
-    //  RootMathCommand(cursor).createLeftOf(cursor);
-    //}
-    //else {
-      var html;
-      if (ch === '<') html = '&lt;';
-      else if (ch === '>') html = '&gt;';
-      VanillaSymbol(ch, html).createLeftOf(cursor);
-    //}
+    var html;
+    if (ch === '<') html = '&lt;';
+    else if (ch === '>') html = '&gt;';
+    VanillaSymbol(ch, html).createLeftOf(cursor);
   };
 });
 API.TextField = function(APIClasses) {

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -337,19 +337,7 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
 
     this.ends[L].cursor = this.cursor;
     this.ends[L].write = function(cursor, ch) {
-      if (ch !== '$')
-        MathBlock.prototype.write.call(this, cursor, ch);
-      else if (this.isEmpty()) {
-        cursor.insRightOf(this.parent);
-        this.parent.deleteTowards(dir, cursor);
-        VanillaSymbol('\\$','$').createLeftOf(cursor.show());
-      }
-      else if (!cursor[R])
-        cursor.insRightOf(this.parent);
-      else if (!cursor[L])
-        cursor.insLeftOf(this.parent);
-      else
-        MathBlock.prototype.write.call(this, cursor, ch);
+      MathBlock.prototype.write.call(this, cursor, ch);
     };
   };
   _.latex = function() {
@@ -360,18 +348,24 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
 var RootTextBlock = P(RootMathBlock, function(_, super_) {
   _.keystroke = function(key) {
     if (key === 'Spacebar' || key === 'Shift-Spacebar') return;
-    return super_.keystroke.apply(this, arguments);
+
+    if ( key === "Ctrl-M") {
+      RootMathCommand(this.cursor).createLeftOf(this.cursor);
+    }
+
+    //return super_.keystroke.apply(this, arguments);
   };
   _.write = function(cursor, ch) {
     cursor.show().deleteSelection();
-    if (ch === '$')
-      RootMathCommand(cursor).createLeftOf(cursor);
-    else {
+    //if (ch === '$') {
+    //  RootMathCommand(cursor).createLeftOf(cursor);
+    //}
+    //else {
       var html;
       if (ch === '<') html = '&lt;';
       else if (ch === '>') html = '&gt;';
       VanillaSymbol(ch, html).createLeftOf(cursor);
-    }
+    //}
   };
 });
 API.TextField = function(APIClasses) {

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -351,9 +351,10 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
 
     if ( key === "Ctrl-M") {
       RootMathCommand(this.cursor).createLeftOf(this.cursor);
+      return;
     }
 
-    //return super_.keystroke.apply(this, arguments);
+    return super_.keystroke.apply(this, arguments);
   };
   _.write = function(cursor, ch) {
     cursor.show().deleteSelection();

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -75,7 +75,7 @@ var latexMathParser = (function() {
 
 Controller.open(function(_, super_) {
   _.exportLatex = function() {
-    return this.root.latex().replace(/(\\[a-z]+) (?![a-z])/ig,'$1');
+    return this.root.latex().replace(/(\\[a-z]+) (?![a-z])/ig,'$1').replace(/^\$/g,"\\$").replace(/([^\\])\$/g,"$1\\$").replace(/([^\\])\$/g,"$1\\$").replace(/(\\mqmm *|\\endmqmm)/g,"$");
   };
   _.writeLatex = function(latex) {
     var cursor = this.notify('edit').cursor;


### PR DESCRIPTION
This allows users to type "Ctrl-M" in mathquill textareas to switch between text and math mode.