### PR TITLE
Student mathquill

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -369,6 +369,14 @@ var MathBlock = P(MathElement, function(_, super_) {
       ctrlr.escapeDir(key === 'Shift-Spacebar' ? L : R, key, e);
       return;
     }
+
+    if ( key === "Ctrl-M") {
+      if (!ctrlr.cursor[R])
+        ctrlr.cursor.insRightOf(this.parent);
+      else if (!ctrlr.cursor[L])
+        ctrlr.cursor.insLeftOf(this.parent);
+    }
+
     return super_.keystroke.apply(this, arguments);
   };
 

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -370,12 +370,15 @@ var MathBlock = P(MathElement, function(_, super_) {
       return;
     }
 
-    if ( key === "Ctrl-M") {
+    if ( key === "Ctrl-M" || key === "Meta-M" ) {
       if (!ctrlr.cursor[R])
         ctrlr.cursor.insRightOf(this.parent);
       else if (!ctrlr.cursor[L])
         ctrlr.cursor.insLeftOf(this.parent);
+
+      e.preventDefault();
     }
+
 
     return super_.keystroke.apply(this, arguments);
   };

--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -12,11 +12,18 @@ LatexCmds.otimes = P(BinaryOperator, function(_, super_) {
   };
 });
 
+// EAS use entity to prevent confusion with a tilde or tie (&nbsp;)
+LatexCmds.sim = bind(BinaryOperator, '\\sim ', '&#126;');
+
 LatexCmds['≠'] = LatexCmds.ne = LatexCmds.neq = bind(BinaryOperator,'\\ne ','&ne;');
 
-LatexCmds.ast = LatexCmds.star = LatexCmds.loast = LatexCmds.lowast =
+// EAS separate asterisk and star
+LatexCmds.ast = LatexCmds.loast = LatexCmds.lowast =
   bind(BinaryOperator,'\\ast ','&lowast;');
-  //case 'there4 = // a special exception for this one, perhaps?
+
+LatexCmds.star = bind(BinaryOperator,'\\star','&#8902;');
+
+//case 'there4 = // a special exception for this one, perhaps?
 LatexCmds.therefor = LatexCmds.therefore =
   bind(BinaryOperator,'\\therefore ','&there4;');
 
@@ -201,9 +208,15 @@ LatexCmds.clubsuit = bind(VanillaSymbol, '\\clubsuit ', '&#9827;');
 LatexCmds.diamondsuit = bind(VanillaSymbol, '\\diamondsuit ', '&#9826;');
 LatexCmds.heartsuit = bind(VanillaSymbol, '\\heartsuit ', '&#9825;');
 LatexCmds.spadesuit = bind(VanillaSymbol, '\\spadesuit ', '&#9824;');
-//not real LaTex command see https://github.com/mathquill/mathquill/pull/552 for more details
-LatexCmds.parallelogram = bind(VanillaSymbol, '\\parallelogram ', '&#9649;');
-LatexCmds.square = bind(VanillaSymbol, '\\square ', '&#11036;');
+
+// EAS geometry
+LatexCmds.llgram = LatexCmds.parallelogram =
+  bind(VanillaSymbol, '\\llgram ', '&#9649;');
+LatexCmds.square = LatexCmds.whitesquare =
+  bind(VanillaSymbol, '\\square ', '&#11036;');
+LatexCmds.quadr = LatexCmds.quadrilateral =
+LatexCmds.rect = LatexCmds.rectangle =
+  bind(VanillaSymbol, '\\quadr ', '&#9645;');
 
 //variable-sized
 LatexCmds.oint = bind(VanillaSymbol, '\\oint ', '&#8750;');
@@ -307,17 +320,17 @@ LatexCmds.alef = LatexCmds.alefsym = LatexCmds.aleph = LatexCmds.alephsym =
 LatexCmds.exist = LatexCmds.exists =
   bind(VanillaSymbol,'\\exists ','&exist;');
 
-LatexCmds.nexists = LatexCmds.nexist =
-      bind(VanillaSymbol, '\\nexists ', '&#8708;');
+// EAS
+LatexCmds.nexists = LatexCmds.nexist = LatexCmds.notexists =
+  bind(VanillaSymbol, '\\nexists ', '&#8708;');
 
 LatexCmds.and = LatexCmds.land = LatexCmds.wedge =
   bind(VanillaSymbol,'\\wedge ','&and;');
 
 LatexCmds.or = LatexCmds.lor = LatexCmds.vee = bind(VanillaSymbol,'\\vee ','&or;');
 
-LatexCmds.empty = LatexCmds.emptyset =
-LatexCmds.es = LatexCmds.nothing =
-LatexCmds.varnothing = bind(BinaryOperator,'\\varnothing ','&empty;');
+LatexCmds.es = LatexCmds.emptyset = LatexCmds.empty =
+LatexCmds.varnothing = LatexCmds.nothing = bind(BinaryOperator,'\\varnothing ','&empty;');
 
 LatexCmds.cup = LatexCmds.union = bind(BinaryOperator,'\\cup ','&cup;');
 

--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -299,7 +299,7 @@ LatexCmds.part = LatexCmds.partial = bind(VanillaSymbol,'\\partial ','&part;');
 LatexCmds.infty = LatexCmds.infin = LatexCmds.infinity = LatexCmds.inf =
   bind(VanillaSymbol,'\\infty ','&infin;');
 
-LatexCmds.florin = bind(VanillaSymbol,'\\florin ','&fnof;');
+LatexCmds.eff = LatexCmds.scriptf = LatexCmds.fnof = LatexCmds.florin = bind(VanillaSymbol,'\\florin ','&fnof;');
 
 LatexCmds.alef = LatexCmds.alefsym = LatexCmds.aleph = LatexCmds.alephsym =
   bind(VanillaSymbol,'\\aleph ','&alefsym;');

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -504,4 +504,4 @@ LatexCmds['×'] = LatexCmds.times = LatexCmds.x = bind(BinaryOperator, '\\times 
 LatexCmds['÷'] = LatexCmds.div = LatexCmds.d = LatexCmds.divide = LatexCmds.divides =
   bind(BinaryOperator,'\\div ','&divide;', '[/]');
 
-CharCmds['~'] = LatexCmds.sim = bind(BinaryOperator, '\\sim ', '~', '~');
+CharCmds['~'] = LatexCmds.tie = LatexCmds.nbsp = bind(VanillaSymbol, '~', '&nbsp;');

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -76,15 +76,19 @@ LatexCmds.mathit = bind(Style, '\\mathit', 'i', 'class="mq-font"');
 LatexCmds.mathbf = bind(Style, '\\mathbf', 'b', 'class="mq-font"');
 LatexCmds.mathsf = bind(Style, '\\mathsf', 'span', 'class="mq-sans-serif mq-font"');
 LatexCmds.mathtt = bind(Style, '\\mathtt', 'span', 'class="mq-monospace mq-font"');
+
 //text-decoration
 LatexCmds.underline = bind(Style, '\\underline', 'span', 'class="mq-non-leaf mq-underline"');
-LatexCmds.overline = LatexCmds.bar = LatexCmds.seg = bind(Style, '\\overline', 'span', 'class="mq-non-leaf mq-overline"');
+LatexCmds.overline = bind(Style, '\\overline', 'span', 'class="mq-non-leaf mq-overline"');
 LatexCmds.overrightarrow = bind(Style, '\\overrightarrow', 'span', 'class="mq-non-leaf mq-overarrow mq-arrow-right"');
 LatexCmds.overleftarrow = bind(Style, '\\overleftarrow', 'span', 'class="mq-non-leaf mq-overarrow mq-arrow-left"');
+
+// EAS \bar and \seg should be separate from \overline, typesetting is different
+LatexCmds.bar = bind(Style, '\\bar', 'span', 'class="mq-non-leaf mq-overline"');
+LatexCmds.seg = bind(Style, '\\seg', 'span', 'class="mq-non-leaf mq-overline"');
 LatexCmds.arc = bind(Style, '\\arc', 'span', 'class="mq-non-leaf mq-overline mq-arc"');
 LatexCmds.ray = bind(Style, '\\ray', 'span', 'class="mq-non-leaf mq-overarrow mq-arrow-right"');
 LatexCmds.line = LatexCmds.lin = bind(Style, '\\lin', 'span', 'class="mq-non-leaf mq-overarrow mq-line"');
-
 
 // `\textcolor{color}{math}` will apply a color to the given math content, where
 // `color` is any valid CSS Color Value (see [SitePoint docs][] (recommended),

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -378,5 +378,8 @@ API.TextField = function(APIClasses) {
       }
       return this.__controller.exportLatex();
     };
+    _.addMathBlock = function() {
+      return RootMathCommand(this.__controller.cursor).createLeftOf(this.__controller.cursor);
+    }
   });
 };

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -341,7 +341,7 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
     };
   };
   _.latex = function() {
-    return '$' + this.ends[L].latex() + '$';
+    return "\\mqmm " + this.ends[L].latex() + "\\endmqmm";
   };
 });
 
@@ -358,15 +358,10 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
   };
   _.write = function(cursor, ch) {
     cursor.show().deleteSelection();
-    //if (ch === '$') {
-    //  RootMathCommand(cursor).createLeftOf(cursor);
-    //}
-    //else {
-      var html;
-      if (ch === '<') html = '&lt;';
-      else if (ch === '>') html = '&gt;';
-      VanillaSymbol(ch, html).createLeftOf(cursor);
-    //}
+    var html;
+    if (ch === '<') html = '&lt;';
+    else if (ch === '>') html = '&gt;';
+    VanillaSymbol(ch, html).createLeftOf(cursor);
   };
 });
 API.TextField = function(APIClasses) {

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -337,19 +337,7 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
 
     this.ends[L].cursor = this.cursor;
     this.ends[L].write = function(cursor, ch) {
-      if (ch !== '$')
-        MathBlock.prototype.write.call(this, cursor, ch);
-      else if (this.isEmpty()) {
-        cursor.insRightOf(this.parent);
-        this.parent.deleteTowards(dir, cursor);
-        VanillaSymbol('\\$','$').createLeftOf(cursor.show());
-      }
-      else if (!cursor[R])
-        cursor.insRightOf(this.parent);
-      else if (!cursor[L])
-        cursor.insLeftOf(this.parent);
-      else
-        MathBlock.prototype.write.call(this, cursor, ch);
+      MathBlock.prototype.write.call(this, cursor, ch);
     };
   };
   _.latex = function() {
@@ -360,18 +348,24 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
 var RootTextBlock = P(RootMathBlock, function(_, super_) {
   _.keystroke = function(key) {
     if (key === 'Spacebar' || key === 'Shift-Spacebar') return;
-    return super_.keystroke.apply(this, arguments);
+
+    if ( key === "Ctrl-M") {
+      RootMathCommand(this.cursor).createLeftOf(this.cursor);
+    }
+
+    //return super_.keystroke.apply(this, arguments);
   };
   _.write = function(cursor, ch) {
     cursor.show().deleteSelection();
-    if (ch === '$')
-      RootMathCommand(cursor).createLeftOf(cursor);
-    else {
+    //if (ch === '$') {
+    //  RootMathCommand(cursor).createLeftOf(cursor);
+    //}
+    //else {
       var html;
       if (ch === '<') html = '&lt;';
       else if (ch === '>') html = '&gt;';
       VanillaSymbol(ch, html).createLeftOf(cursor);
-    }
+    //}
   };
 });
 API.TextField = function(APIClasses) {

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -351,9 +351,10 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
 
     if ( key === "Ctrl-M") {
       RootMathCommand(this.cursor).createLeftOf(this.cursor);
+      return;
     }
 
-    //return super_.keystroke.apply(this, arguments);
+    return super_.keystroke.apply(this, arguments);
   };
   _.write = function(cursor, ch) {
     cursor.show().deleteSelection();

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -346,13 +346,15 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
 });
 
 var RootTextBlock = P(RootMathBlock, function(_, super_) {
-  _.keystroke = function(key) {
+  _.keystroke = function(key, e, ctrlr) {
     if (key === 'Spacebar' || key === 'Shift-Spacebar') return;
 
-    if ( key === "Ctrl-M") {
+    if ( key === "Ctrl-M" || key === "Meta-M" ) {
       RootMathCommand(this.cursor).createLeftOf(this.cursor);
+      e.preventDefault();
       return;
     }
+
 
     return super_.keystroke.apply(this, arguments);
   };
@@ -378,8 +380,5 @@ API.TextField = function(APIClasses) {
       }
       return this.__controller.exportLatex();
     };
-    _.addMathBlock = function() {
-      return RootMathCommand(this.__controller.cursor).createLeftOf(this.__controller.cursor);
-    }
   });
 };

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -75,7 +75,7 @@ var latexMathParser = (function() {
 
 Controller.open(function(_, super_) {
   _.exportLatex = function() {
-    return this.root.latex().replace(/(\\[a-z]+) (?![a-z])/ig,'$1');
+    return this.root.latex().replace(/(\\[a-z]+) (?![a-z])/ig,'$1').replace(/^\$/g,"\\$").replace(/([^\\])\$/g,"$1\\$").replace(/([^\\])\$/g,"$1\\$").replace(/(\\mqmm *|\\endmqmm)/g,"$");
   };
   _.writeLatex = function(latex) {
     var cursor = this.notify('edit').cursor;


### PR DESCRIPTION
This adds a hotkey Ctrl-M to mathquill's textarea to turn math mode on and off (opposed to the dollar sign).

This also includes the branch florin-aliases.

@gcortright ready for review